### PR TITLE
Compiling with Ocaml 4.06.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ _build/
 /tests/arith/div
 /tests/arith/mod
 /tests/arith/mul
+/tests/byte/byte
 /tests/chargen/chargen
 /tests/charger/charger
 /tests/eeprom/test

--- a/configure
+++ b/configure
@@ -219,11 +219,11 @@ define clean
 endef
 define capitalize
  \$(shell echo \$1 | cut -c1 | tr [:lower:] [:upper:])\$(shell echo \$1 \
-| cut -c2-\$)
+| cut -c2-\$2)
 endef
 define uncapitalize
  \$(shell echo \$1 | cut -c1 | tr [:upper:] [:lower:])\$(shell echo \$1 \
-| cut -c2-\$)
+| cut -c2-\$2)
 endef
 
 " > etc/Makefile.conf

--- a/lib/camlinternalFormat.ml
+++ b/lib/camlinternalFormat.ml
@@ -289,15 +289,15 @@ let format_int fmt n =
                   match nstr.[0] with
                     | ('-' as c) | ('+' as c) ->
                         Bytes.set res 0 c;
-                        Bytes.blit nstr 1 res (fsz - nsz + 1) (nsz - 1);
+                        Bytes.blit_string nstr 1 res (fsz - nsz + 1) (nsz - 1);
                         Bytes.unsafe_to_string res
                     | _ ->
-                        Bytes.blit nstr 0 res (fsz - nsz) nsz;
+                        Bytes.blit_string nstr 0 res (fsz - nsz) nsz;
                         Bytes.unsafe_to_string res
               else
                 let res = Bytes.make fsz ' ' in
                 let ofs = if minus then 0 else fsz - nsz in
-                  Bytes.blit nstr 0 res ofs nsz;
+                  Bytes.blit_string nstr 0 res ofs nsz;
                   Bytes.unsafe_to_string res
             else
               nstr

--- a/lib/int32.ml
+++ b/lib/int32.ml
@@ -238,15 +238,15 @@ let format fmt n =
                   match nstr.[0] with
                     | ('-' as c) | ('+' as c) ->
                         Bytes.set res 0 c;
-                        Bytes.blit nstr 1 res (fsz - nsz + 1) (nsz - 1);
+                        Bytes.blit_string nstr 1 res (fsz - nsz + 1) (nsz - 1);
                         Bytes.unsafe_to_string res
                     | _ ->
-                        Bytes.blit nstr 0 res (fsz - nsz) nsz;
+                        Bytes.blit_string nstr 0 res (fsz - nsz) nsz;
                         Bytes.unsafe_to_string res
               else
                 let res = Bytes.make fsz ' ' in
                 let ofs = if minus then 0 else fsz - nsz in
-                  Bytes.blit nstr 0 res ofs nsz;
+                  Bytes.blit_string nstr 0 res ofs nsz;
                   Bytes.unsafe_to_string res
             else
               nstr

--- a/lib/int64.ml
+++ b/lib/int64.ml
@@ -88,7 +88,7 @@ let to_string n =
       let _ = f 19 max_int in
         Bytes.set str 19 '8';
         Bytes.set str 0 '-';
-        str
+        (Bytes.to_string str)
     else
       let b = f 19 (neg n) - 1 in
       Bytes.set str b '-';
@@ -245,15 +245,15 @@ let format fmt n =
                   match nstr.[0] with
                     | ('-' as c) | ('+' as c) ->
                         Bytes.set res 0 c;
-                        Bytes.blit nstr 1 res (fsz - nsz + 1) (nsz - 1);
+                        Bytes.blit_string nstr 1 res (fsz - nsz + 1) (nsz - 1);
                         Bytes.unsafe_to_string res
                     | _ ->
-                        Bytes.blit nstr 0 res (fsz - nsz) nsz;
+                        Bytes.blit_string nstr 0 res (fsz - nsz) nsz;
                         Bytes.unsafe_to_string res
               else
                 let res = Bytes.make fsz ' ' in
                 let ofs = if minus then 0 else fsz - nsz in
-                  Bytes.blit nstr 0 res ofs nsz;
+                  Bytes.blit_string nstr 0 res ofs nsz;
                   Bytes.unsafe_to_string res
             else
               nstr

--- a/src/asm/stdlib.asm
+++ b/src/asm/stdlib.asm
@@ -16,7 +16,11 @@
 ;;;;;;;;                                   ;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+#ifdef caml_useprim_caml_blit_bytes
+#define caml_useprim_caml_blit_string
+#endif
 #ifdef caml_useprim_caml_blit_string
+caml_blit_bytes:
 caml_blit_string:
 	;; ACCU = src
 	;; [0x2]:[0x1] = srcoff
@@ -58,7 +62,11 @@ caml_blit_string_loop_test:
 	return
 #endif
 
+#ifdef caml_useprim_caml_ml_bytes_length
+#define caml_useprim_caml_ml_string_length
+#endif
 #ifdef caml_useprim_caml_ml_string_length
+caml_ml_bytes_length:
 caml_ml_string_length:
 	;; ACCU = str
 	movff	ACCUL, FSR0L	; FSR0 <- ACCU
@@ -85,7 +93,11 @@ caml_ml_string_length:
 	return
 #endif
 
+#ifdef caml_useprim_caml_fill_bytes
+#define caml_useprim_caml_fill_string
+#endif
 #ifdef caml_useprim_caml_fill_string
+caml_fill_bytes:
 caml_fill_string:
 	;; ACCU = str
 	;; [0x2]:[0x1] = start
@@ -121,6 +133,7 @@ caml_fill_string_miloop:
 #ifndef caml_useprim_caml_raise_ia_string_create
 #define caml_useprim_caml_raise_ia_string_create
 #endif
+caml_create_bytes:
 caml_create_string:
 	;; ACCU = len
 	rrcf	ACCUH, W	; STATUS.C ignored
@@ -156,10 +169,14 @@ caml_create_string:
 	return
 #endif
 
+#ifdef caml_useprim_caml_bytes_get
+#define caml_useprim_caml_string_get
+#endif
 #ifdef caml_useprim_caml_string_get
 #ifndef caml_useprim_caml_raise_ia_index_out_of_bounds_string
 #define caml_useprim_caml_raise_ia_index_out_of_bounds_string
 #endif
+caml_bytes_get:
 caml_string_get:
 	;; ACCU = str
 	;; [0x2]:[0x1] = ind
@@ -206,10 +223,14 @@ caml_string_get_last_char:
 	return
 #endif
 
+#ifdef caml_useprim_caml_bytes_set
+#define caml_useprim_caml_string_set
+#endif
 #ifdef caml_useprim_caml_string_set
 #ifndef caml_useprim_caml_raise_ia_index_out_of_bounds_string
 #define caml_useprim_caml_raise_ia_index_out_of_bounds_string
 #endif
+caml_bytes_set:
 caml_string_set:
 	;; ACCU = str
 	;; [0x2]:[0x1] = ind

--- a/tests/byte/Makefile
+++ b/tests/byte/Makefile
@@ -1,0 +1,39 @@
+###########################################################################
+##                                                                       ##
+##                                OCaPIC                                 ##
+##                                                                       ##
+##                             Benoit Vaugon                             ##
+##                                                                       ##
+##    This file is distributed under the terms of the CeCILL license.    ##
+##    See file ../../LICENSE-en.                                         ##
+##                                                                       ##
+###########################################################################
+
+include ../../etc/TestsMakefile.conf
+
+BASE = byte
+PIC = 18f4620
+
+all: $(BASE).hex
+
+$(BASE).hex: $(BASE).asm
+	gpasm -y $(BASE).asm
+
+$(BASE) $(BASE).asm: $(BASE).ml
+	$(OCAPIC) $(PIC) $(BASE).ml $$($(OCAPIC) -where)/default-config.asm
+
+simul1: $(BASE)
+	./$(BASE) ocapic_dip40_simulator \
+	  'ocapic_lcd_simulator 16x2 e=RD0 rs=RD2 rw=RD1 bus=PORTB'
+
+simul2: $(BASE).hex
+	ocasim $(BASE).hex ocapic_dip40_simulator \
+	  'ocapic_lcd_simulator 16x2 e=RD0 rs=RD2 rw=RD1 bus=PORTB'
+
+prog: $(BASE).hex
+	picprog $(BASE).hex
+
+clean:
+	@rm -f *~ *.o *.cmo *.cmi *.hex *.cod *.lst $(BASE).asm $(BASE)
+
+.PHONY: all simul1 simul2 prog clean

--- a/tests/byte/byte.ml
+++ b/tests/byte/byte.ml
@@ -1,0 +1,32 @@
+(*************************************************************************)
+(*                                                                       *)
+(*                                OCaPIC                                 *)
+(*                                                                       *)
+(*                             Benoit Vaugon                             *)
+(*                                                                       *)
+(*    This file is distributed under the terms of the CeCILL license.    *)
+(*    See file ../../LICENSE-en.                                         *)
+(*                                                                       *)
+(*************************************************************************)
+
+open Pic;;
+open Lcd;;
+open Bytes;;
+
+set_bit IRCF1;;
+set_bit IRCF0;;
+set_bit PLLEN;;
+
+let disp = connect ~bus_size:Lcd.Four ~e:LATD0 ~rs:LATD2 ~rw:LATD1 ~bus:PORTB;;
+
+let _ =
+  disp.init ();
+  disp.config ();
+
+  let b = Bytes.create 11 in
+  Bytes.set b 0 'H';
+  Bytes.blit_string "ello warld" 0 b 1 10;
+  Bytes.set b 7 (Bytes.get b 4);
+  disp.print_string (Bytes.to_string b);
+
+  while true do () done


### PR DESCRIPTION
I made some slight modifications to allow ocapic to be compiled using the version 4.06.1 of the OCaml compiler : they mainly consist in converting some strings into bytes, and some bytes into strings. I also aliased some of the string functions defined in *stdlib.asm* (such as `caml_string_set`) to cover the similar bytes functions.

Moreover, I fixed the issue highlighted in #1.

I ran a few of the tests, and everything seems to work correctly. However, this does not work with the 4.07 OCaml compiler, due to the changes to the handling of stdlib between 4.06 and 4.07.
